### PR TITLE
Implement cli suggestions from #34, #35 and #36

### DIFF
--- a/fractopo/cli.py
+++ b/fractopo/cli.py
@@ -89,7 +89,8 @@ def describe_results(
             type_color = "bold red"
     count_color = "bold red" if error_count / trace_count > 0.05 else "yellow"
     console.print(Text.assemble((count_string, count_color)))
-    console.print(Text.assemble((type_string, type_color)))
+    if len(error_types) > 0:
+        console.print(Text.assemble((type_string, type_color)))
 
 
 def make_output_dir(trace_path: Path) -> Path:

--- a/fractopo/cli.py
+++ b/fractopo/cli.py
@@ -93,7 +93,7 @@ def describe_results(
         console.print(Text.assemble((type_string, type_color)))
 
 
-def make_output_dir(trace_path: Path) -> Path:
+def make_output_dir(base_path: Path) -> Path:
     """
     Make timestamped output dir.
     """
@@ -104,7 +104,7 @@ def make_output_dir(trace_path: Path) -> Path:
     month = localtime.tm_mon
     year = localtime.tm_year
     timestr = "_".join(map(str, [day, month, year, hour, tm_min]))
-    output_dir = trace_path.parent / f"validated_{timestr}"
+    output_dir = base_path / f"validated_{timestr}"
     if not output_dir.exists():
         output_dir.mkdir()
     return output_dir
@@ -227,17 +227,13 @@ def tracevalidate(
 
     # Resolve output if not explicitly given
     if output is None:
-        output_dir = make_output_dir(trace_file)
-        output_path = (
-            trace_file.parent
-            / output_dir
-            / f"{trace_file.stem}_validated{trace_file.suffix}"
-        )
+        output_dir = make_output_dir(Path(".")).resolve()
+        output_path = output_dir / f"{trace_file.stem}_validated{trace_file.suffix}"
         CONSOLE.print(
             Text.assemble(
                 (
-                    f"Generated output directory at {output_dir}"
-                    f"\nwhere validated output will be saved at {output_path}.",
+                    f"Generated output directory at {output_dir} "
+                    f"where validated output will be saved in file {output_path.name}.",
                     "blue",
                 )
             )

--- a/fractopo/cli.py
+++ b/fractopo/cli.py
@@ -159,7 +159,10 @@ def tracevalidate(
         True,
         "--allow-fix",
         "--fix",
-        help="Allow the direct modification of trace file to fix errors.",
+        help=(
+            "Enable the direct modification of output trace file to fix errors. "
+            "Input files will not be modified unless specified as the --output target."
+        ),
     ),
     summary: bool = typer.Option(True, help="Print summary of validation results."),
     snap_threshold: float = typer.Option(

--- a/fractopo/general.py
+++ b/fractopo/general.py
@@ -2087,3 +2087,16 @@ def sanitize_name(name: str) -> str:
     Return only alphanumeric parts of name string.
     """
     return "".join(filter(str.isalnum, name))
+
+
+def check_for_wrong_geometries(traces: gpd.GeoDataFrame, area: gpd.GeoDataFrame):
+    """
+    Check that traces are line geometries and area contains area geometries.
+    """
+    accepted_line_types = (LineString, MultiLineString)
+    accepted_area_types = (Polygon, MultiPolygon)
+    for name, geoms, accepted_types in zip(
+        ("traces", "area"), (traces, area), (accepted_line_types, accepted_area_types)
+    ):
+        if not all(isinstance(geom, accepted_types) for geom in geoms.geometry.values):
+            raise TypeError(f"Expected {name} to contain only any of {accepted_types}.")

--- a/fractopo/tval/trace_validation.py
+++ b/fractopo/tval/trace_validation.py
@@ -90,7 +90,11 @@ class Validation:
                 """
                 ).strip()
             )
-            self.traces = remove_z_coordinates_from_geodata(geodata=self.traces)
+            traces_with_removed_z = remove_z_coordinates_from_geodata(
+                geodata=self.traces
+            )
+            assert isinstance(traces_with_removed_z, gpd.GeoDataFrame)
+            self.traces = traces_with_removed_z
 
     def set_general_nodes(self):
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,15 +53,16 @@ def test_tracevalidate_typer(
     assert Validation.ERROR_COLUMN in output_gdf.columns
     if "--summary" in cli_args:
         assert "Out of" in result.output
-        assert "There were" in result.output
+        if not "There were" in result.output:
+            assert "0 were invalid" in result.output
 
 
 def test_make_output_dir(tmp_path):
     """
     Test make_output_dir.
     """
-    some_file = Path(tmp_path) / "some.file"
-    output_dir = cli.make_output_dir(some_file)
+    some_dir = Path(tmp_path)
+    output_dir = cli.make_output_dir(some_dir)
     assert output_dir.exists()
     assert output_dir.is_dir()
 


### PR DESCRIPTION
-   Validated trace data is now saved to the current directory when the
    output is not set by the user by default, in contrast to saving
    relative to the input trace data as suggested in #34.

-   The help text for the `--allow-fix` flag has been modified as
    suggested in #35 to make it clearer.

-   Command-line invocations of ``tracevalidate`` and ``network``
    will now fail fast if the passed trace and area data geometries
    are not what is expected. E.g. if they are passed in the wrong order.
    Should help with issue #36.
