### PR TITLE
Do not build documentation by default

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,6 +17,8 @@ jobs:
           name: fractopo
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Check with nix
+        # This also builds documentation (fractopo-documentation) so docs job
+        # does not have to run every time
         run: |
           nix flake check
   poetry:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/nix-installer-action@v8
       - uses: DeterminateSystems/magic-nix-cache-action@v2
       - uses: cachix/cachix-action@v12
         with:
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@v2
+      - uses: DeterminateSystems/nix-installer-action@v8
       - uses: DeterminateSystems/magic-nix-cache-action@v2
       - uses: cachix/cachix-action@v12
         with:
@@ -43,7 +43,7 @@ jobs:
     needs: [nix, poetry]
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@v2
+      - uses: DeterminateSystems/nix-installer-action@v8
       - uses: DeterminateSystems/magic-nix-cache-action@v2
       - uses: cachix/cachix-action@v12
         with:
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/nix-installer-action@v8
       - uses: DeterminateSystems/magic-nix-cache-action@v2
       - uses: cachix/cachix-action@v12
         with:
@@ -116,7 +116,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Build documentation
         run: |
-          nix build .#fractopo.doc
+          nix build .#fractopo.passthru.documentation.doc
           cp -Lr --no-preserve=mode,ownership,timestamps ./result-doc/share/doc/* ./docs
       - uses: actions/upload-pages-artifact@v2
         with:

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 , scipy, seaborn, shapely, typer, pytest-regressions, hypothesis, fetchPypi
 , mpmath, poetry-core, sphinxHook, pandoc, sphinx-autodoc-typehints
 , sphinx-rtd-theme, sphinx-gallery, nbsphinx, notebook, ipython, coverage
-, filter
+, filter,
 
 }:
 
@@ -95,24 +95,31 @@ let
     nativeBuildInputs = [
       # Uses poetry for install
       poetry-core
-      # Documentation dependencies
-      sphinxHook
-      pandoc
-      sphinx-autodoc-typehints
-      sphinx-rtd-theme
-      sphinx-gallery
-      nbsphinx
-      matplotlib
-      notebook
-      ipython
     ];
 
-    # Enables building package and docs without tests
-    # nix build .#fractopo.passthru.no-check.doc
-    passthru.no-check = self.overridePythonAttrs (_: { doCheck = false; });
-
-    sphinxRoot = "docs_src";
-    outputs = [ "out" "doc" ];
+    passthru = {
+      # Enables building package without tests
+      # nix build .#fractopo.passthru.no-check
+      no-check = self.overridePythonAttrs (_: { doCheck = false; });
+      # Documentation without tests
+      documentation = self.overridePythonAttrs (prevAttrs: {
+        doCheck = false;
+        nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [
+          # Documentation dependencies
+          sphinxHook
+          pandoc
+          sphinx-autodoc-typehints
+          sphinx-rtd-theme
+          sphinx-gallery
+          nbsphinx
+          matplotlib
+          notebook
+          ipython
+        ];
+        sphinxRoot = "docs_src";
+        outputs = [ "out" "doc" ];
+      });
+    };
 
     propagatedBuildInputs = [
       click

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
           # fractopo39 = pkgs.python39Packages.fractopo;
           fractopo310 = pkgs.python310Packages.fractopo;
           fractopo311 = pkgs.python311Packages.fractopo;
+          fractopo-documentation = pkgs.fractopo.passthru.documentation;
         };
         devShells = {
           default = pkgs.mkShell {


### PR DESCRIPTION
Default build now does not build documentation. Documentation is mostly meant for online consumption, not for local such as for `man` pages.
