### PR TITLE
Ignore depr. warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ filterwarnings =[
     # upstream powerlaw error
     "ignore:Standard error for the MLE should be accessed using the 'standard_err' property.:DeprecationWarning",
     "ignore:'asyncio.WindowsSelectorEventLoopPolicy' is deprecated and slated for removal in Python 3.16:DeprecationWarning",
+    "ignore:'asyncio.set_event_loop_policy' is deprecated and slated for removal in Python 3.16:DeprecationWarning",
 ]
 
 # [tool.isort]


### PR DESCRIPTION
- **feat(marimos): add empty GeoDataFrame check with tests**
- **test: ignore WindowsSelectorEventLoopPolicy DeprecationWarning**
- **test: ignore set_event_loop_policy warn**
