### PR TITLE
Silence warnings in tests and docs builds

### DIFF
--- a/fractopo/analysis/length_distributions.py
+++ b/fractopo/analysis/length_distributions.py
@@ -471,7 +471,6 @@ class MultiLengthDistribution:
         )
 
 
-@general.JOBLIB_CACHE.cache
 @beartype
 def determine_fit(
     length_array: np.ndarray, cut_off: Optional[float] = None

--- a/fractopo/general.py
+++ b/fractopo/general.py
@@ -8,6 +8,7 @@ import math
 import os
 import random
 import re
+import warnings
 from bisect import bisect
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
@@ -47,6 +48,13 @@ from shapely.ops import split
 from sklearn.linear_model import LinearRegression
 
 log = logging.getLogger(__name__)
+
+
+class ShapefileLimitWarning(UserWarning):
+    """
+    Shapefile export truncates or renames some field names.
+    """
+
 
 styled_text_dict = {
     "path_effects": [path_effects.withStroke(linewidth=3, foreground="k")],
@@ -2020,7 +2028,24 @@ def write_geodataframe(geodataframe: gpd.GeoDataFrame, name: str, results_dir: P
     try:
         shp_dir = results_dir / f"{name}_as_shp"
         shp_dir.mkdir(exist_ok=False)
-        geodataframe.to_file(shp_dir / f"{name}.shp")
+        warnings.warn(
+            "Shapefile export truncates long field names and may rename columns; "
+            "use GPKG or GeoJSON for full names.",
+            ShapefileLimitWarning,
+            stacklevel=2,
+        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Column names longer than 10 characters will be truncated.*",
+                category=UserWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message="Normalized/laundered field name: .*",
+                category=RuntimeWarning,
+            )
+            geodataframe.to_file(shp_dir / f"{name}.shp")
     except Exception:
         log.error(error_base.format(name, "ESRI Shapefile (.shp)"), exc_info=True)
     try:

--- a/fractopo/general.py
+++ b/fractopo/general.py
@@ -50,12 +50,6 @@ from sklearn.linear_model import LinearRegression
 log = logging.getLogger(__name__)
 
 
-class ShapefileLimitWarning(UserWarning):
-    """
-    Shapefile export truncates or renames some field names.
-    """
-
-
 styled_text_dict = {
     "path_effects": [path_effects.withStroke(linewidth=3, foreground="k")],
     "color": "white",
@@ -2031,7 +2025,7 @@ def write_geodataframe(geodataframe: gpd.GeoDataFrame, name: str, results_dir: P
         warnings.warn(
             "Shapefile export truncates long field names and may rename columns; "
             "use GPKG or GeoJSON for full names.",
-            ShapefileLimitWarning,
+            UserWarning,
             stacklevel=2,
         )
         with warnings.catch_warnings():

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -2,6 +2,7 @@
 Tests for general utilities.
 """
 
+import warnings
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 
@@ -205,6 +206,40 @@ def test_total_bounds(geodata):
     result = general.total_bounds(geodata=geodata)
     assert isinstance(result, tuple)
     assert len(result) == 4
+
+
+def test_write_geodataframe_warns_once_and_silences_driver_warnings(tmp_path):
+    """
+    Test shapefile export emits one fractopo warning instead of driver spam.
+    """
+    geodataframe = gpd.GeoDataFrame(
+        {
+            "VALIDATION_ERRORS": ["()"],
+            "boundary_weight": [1.0],
+            "azimuth_set": ["1"],
+            "geometry": [LineString([(0, 0), (1, 1)])],
+        },
+        geometry="geometry",
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        general.write_geodataframe(geodataframe, "test_output", tmp_path)
+
+    shapefile_warnings = [
+        warning
+        for warning in caught
+        if isinstance(warning.message, general.ShapefileLimitWarning)
+    ]
+    assert len(shapefile_warnings) == 1
+    assert all(
+        "Column names longer than 10 characters" not in str(warning.message)
+        for warning in caught
+    )
+    assert all(
+        "Normalized/laundered field name:" not in str(warning.message)
+        for warning in caught
+    )
 
 
 class DetermineSetParam(NamedTuple):

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -224,14 +224,12 @@ def test_write_geodataframe_warns_once_and_silences_driver_warnings(tmp_path):
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        general.write_geodataframe(geodataframe, "test_output", tmp_path)
+        with pytest.warns(
+            UserWarning,
+            match="Shapefile export truncates long field names and may rename columns",
+        ):
+            general.write_geodataframe(geodataframe, "test_output", tmp_path)
 
-    shapefile_warnings = [
-        warning
-        for warning in caught
-        if isinstance(warning.message, general.ShapefileLimitWarning)
-    ]
-    assert len(shapefile_warnings) == 1
     assert all(
         "Column names longer than 10 characters" not in str(warning.message)
         for warning in caught


### PR DESCRIPTION
- **fix(length_distributions): stop caching powerlaw fits**
- **fix(general): silence shapefile driver warning spam**
- **refactor(general): simplify shapefile warning**
